### PR TITLE
Add directory for management scripts + docker-gc playbook

### DIFF
--- a/cluster-management/README.md
+++ b/cluster-management/README.md
@@ -1,8 +1,8 @@
-##Cluster Management
+## Cluster Management
 
 This directory contains scripts specific to cluster managment intended to be run after an OCP installation for operationalization purposes.
 
-###Contents:
+### Contents:
 
 1. Garbage collection
 ..* Sets up spotify docker-gc on hosts. Should be run against ansible inventory file. 

--- a/cluster-management/README.md
+++ b/cluster-management/README.md
@@ -5,5 +5,5 @@ This directory contains scripts specific to cluster managment intended to be run
 ### Contents:
 
 1. Garbage collection
-- Sets up spotify docker-gc on hosts. Should be run against ansible inventory file. 
+- Sets up spotify docker-gc on hosts. Should be run a standard 'bring your own' OpenShift-ansible inventory file. The playbook will set up garbage collection on all host with the [node] designation. 
 - View the documentation for spotify docker-gc here: [LINK](https://github.com/spotify/docker-gc)

--- a/cluster-management/README.md
+++ b/cluster-management/README.md
@@ -1,0 +1,9 @@
+##Cluster Management
+
+This directory contains scripts specific to cluster managment intended to be run after an OCP installation for operationalization purposes.
+
+###Contents:
+
+1. Garbage collection
+..* Sets up spotify docker-gc on hosts. Should be run against ansible inventory file. 
+..* View the documentation for spotify docker-gc here: [LINK](https://github.com/spotify/docker-gc)

--- a/cluster-management/README.md
+++ b/cluster-management/README.md
@@ -5,5 +5,5 @@ This directory contains scripts specific to cluster managment intended to be run
 ### Contents:
 
 1. Garbage collection
-..* Sets up spotify docker-gc on hosts. Should be run against ansible inventory file. 
-..* View the documentation for spotify docker-gc here: [LINK](https://github.com/spotify/docker-gc)
+- Sets up spotify docker-gc on hosts. Should be run against ansible inventory file. 
+- View the documentation for spotify docker-gc here: [LINK](https://github.com/spotify/docker-gc)

--- a/cluster-management/garbage-collection/docker-gc-setup.yaml
+++ b/cluster-management/garbage-collection/docker-gc-setup.yaml
@@ -3,7 +3,7 @@
 
 ---
 - name: Setup docker garbage collector
-  hosts: all
+  hosts: nodes
   become: true
   vars:
     # Minimum age of containers and images to remove (seconds)

--- a/cluster-management/garbage-collection/docker-gc-setup.yaml
+++ b/cluster-management/garbage-collection/docker-gc-setup.yaml
@@ -1,0 +1,51 @@
+#The following playbook creates a recurring docker-gc job. It adds the redhat oce-specific images to an excluder file so that vendor availability will not be a potential point of failure.
+
+
+---
+- name: Setup docker garbage collector
+  hosts: all
+  become: true
+  vars:
+    # Minimum age of containers and images to remove (seconds)
+    time: 3600
+
+  tasks:
+  - name: Clone docker-gc repo
+    git:
+      repo: 'https://github.com/spotify/docker-gc.git'
+      dest: /tmp/docker-gc
+  - name: Copy docker-gc script to proper location
+    copy:
+      src: /tmp/docker-gc/docker-gc
+      dest: /usr/sbin/docker-gc
+      remote_src: true
+  - name: Create gc cron job
+    shell: echo -e "#!/bin/bash\nGRACE_PERIOD_SECONDS={{ time }} /usr/sbin/docker-gc" > /etc/cron.hourly/docker-gc
+  - name: Delete temp files
+    file:
+      state: absent
+      path: /tmp/docker-gc
+  - name: Add permissions on cron job
+    file:
+      path: /usr/sbin/docker-gc
+      mode: u=rwX,g=rX,o=rX
+  - name: Add permissions on cron job
+    file:
+      path: /etc/cron.hourly/docker-gc
+      mode: u=rwX,g=rX,o=rX
+  - name: Add exclude file
+    file:
+      path: /etc/docker-gc-exclude
+      state: touch
+      mode: "u=rw,g=r,o=r"
+  - name: Add excluder for Red Hat Images
+    blockinfile:
+      dest: /etc/docker-gc-exclude
+      block: |
+        registry.access.redhat.com/openshift3/ose-haproxy-router:*
+        registry.access.redhat.com/openshift3/ose-deployer:*
+        registry.access.redhat.com/openshift3/ose-sti-builder:*
+        registry.access.redhat.com/openshift3/ose-docker-builder:*
+        registry.access.redhat.com/openshift3/ose-pod:*
+        registry.access.redhat.com/openshift3/ose-docker-registry:*
+        registry.access.redhat.com/openshift3/ose-recycler:*


### PR DESCRIPTION
A docker-gc playbook that sets up docker-gc with OCP images excluded from the ansible inventory file of a cluster. 