### PR TITLE
Fixed link for Backup and Restoration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A collection of code samples to help you get started with OpenShift
 
 ## Solutions
 
-* [Backup and Restoration](./backup-restore/)
+* [Backup and Restoration](./backup_restore/)
 * [Custom Autoscaler](./custom-autoscaler/)
 * [Syncing a Registry for Bootstrapping Disconnected Installs](./disconnected_registry/)
 * [A set of documents and playbooks to operate etcd clusters in OpenShift](./etcd-procedures)


### PR DESCRIPTION
Just changed a single line in the README.md file to fix the backup and restore link