### PR TITLE
Update ocp-master-cert-backup.sh to check if run on master differently

### DIFF
--- a/backup_restore/ocp-master-cert-backup.sh
+++ b/backup_restore/ocp-master-cert-backup.sh
@@ -23,7 +23,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # Check if executed on OSE master
-if ! systemctl status atomic-openshift-master-api >/dev/null 2>&1; then
+if ! [ -d $SOURCE_BACKUP_DIR ] ; then
   echo "ERROR: This script must be run on an OpenShift master. Aborting."
   exit 1
 fi


### PR DESCRIPTION
This fixes redhat-cop/openshift-toolkit#64