### PR TITLE
Updating our image management workflow

### DIFF
--- a/image-management/README.md
+++ b/image-management/README.md
@@ -6,12 +6,12 @@ The purpose of this project is to be used as a bootstrap for an custom base imag
 
 In order to simulate a real world enterprise use case, we define two different _actors_ with different levels of ownership of the process.
 
-- An _Operator_ in this case is someone who has admin access to the OpenShift cluster (e.g. a `cluster-admin`)
+- An _Operations Engineer_ in this case is someone who has admin access to the OpenShift cluster (e.g. a `cluster-admin`)
 - An _Image Builder_ is a generic term for the actor in the organization who has ownership of Base Image Builds. This role would typically have restricted rights to the cluster. In this case, we'll say that an _Image Builder_ has `admin` rights on certain projects related to image building.
 
 The projects here contain the following structures:
 
-- An [OpenShift Applier](https://github.com/redhat-cop/openshift-applier) inventory for the Operator portion of the automation
+- An [OpenShift Applier](https://github.com/redhat-cop/openshift-applier) inventory for the Operations portion of the automation
 - An [OpenShift Applier](https://github.com/redhat-cop/openshift-applier) inventory for the Image Builder portion of the automation.
 - Two sample base image builds
   - [myorg-openjdk18](./myorg-openjdk18) - A sample showing how an org might customize the Red Hat jdk image to insert their corporate CAs
@@ -28,9 +28,12 @@ The workflow we will deploy looks something like this:
 
 ![Image Build Workflow](img/workflow.png)
 
-In this workflow, we use the `image-builds` namespace as the home for running builds. This namespace would be private, accessible only to our _Image Builder_ actor. However, both the Red Hat base images, and the customized `myorg-` images will be hosted in the `openshift` namespace, thus being readable from all other namespaces, and making the resulting content more accessible to the organization. The `buildConfigs` also utilize [_image change triggers_](https://docs.openshift.com/container-platform/3.7/dev_guide/builds/triggering_builds.html#image-change-triggers) to automatically rebuild any time a change is detected in an upstream image. In this way, we ensure that all of our images are always up to date with the latest parent images.
+In this workflow, we use the `image-builds` namespace as the home for running builds. This namespace would be private, accessible only to our _Image Builder_ actor. However, both the Red Hat base images, and the customized `myorg-` images will be hosted in the `openshift` namespace, thus being readable from all other namespaces, and making the resulting content more accessible to the organization. The `buildConfigs` also utilize [_image change triggers_](https://docs.openshift.com/container-platform/3.11/dev_guide/builds/triggering_builds.html#image-change-triggers) to automatically rebuild any time a change is detected in an upstream image. In this way, we ensure that all of our images are always up to date with the latest parent images.
 
 ## Deploying the Workflow
+
+| WARNING: The manifests included in this inventory apply cluster-level role bindings and patch _ImageStreams_ in your `openshift` namespace to enable auto-syncing. |
+| --- |
 
 This project uses [Ansible](https://www.ansible.com/) and [Ansible Galaxy](http://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html) to deploy the workflow.
 

--- a/image-management/applier/image-builder-inventory/group_vars/seed-hosts.yml
+++ b/image-management/applier/image-builder-inventory/group_vars/seed-hosts.yml
@@ -1,4 +1,16 @@
 openshift_cluster_content:
+- object: Patch ImageStreams to enable automatic updates
+  content:
+  - name: OpenJDK
+    file: "{{ inventory_dir }}/../manifests/openjdk18-openshift.yml"
+    params: "{{ inventory_dir }}/../patches/openjdk18-openshift.yml"
+    action: patch
+    namespace: openshift
+  - name: JBoss EAP
+    file: "{{ inventory_dir }}/../manifests/jboss-eap70-openshift.yml"
+    params: "{{ inventory_dir }}/../patches/jboss-eap70-openshift.yml"
+    action: patch
+    namespace: openshift
 - object: Set up Image Builds
   content:
   - name: Image buildConfigs

--- a/image-management/applier/manifests/jboss-eap70-openshift.yml
+++ b/image-management/applier/manifests/jboss-eap70-openshift.yml
@@ -1,0 +1,15 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Red Hat JBoss EAP 7.0
+    openshift.io/image.dockerRepositoryCheck: 2019-02-14T06:50:28Z
+    openshift.io/provider-display-name: Red Hat, Inc.
+    version: 1.4.14
+  creationTimestamp: null
+  generation: 2
+  name: jboss-eap70-openshift
+spec:
+  lookupPolicy:
+    local: false
+  tags:

--- a/image-management/applier/manifests/openjdk18-openshift.yml
+++ b/image-management/applier/manifests/openjdk18-openshift.yml
@@ -1,0 +1,102 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Red Hat OpenJDK 8
+    openshift.io/image.dockerRepositoryCheck: 2019-02-14T06:50:40Z
+    openshift.io/provider-display-name: Red Hat, Inc.
+    version: 1.4.14
+  creationTimestamp: null
+  generation: 2
+  name: redhat-openjdk18-openshift
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+      description: Build and run Java applications using Maven and OpenJDK 8.
+      iconClass: icon-rh-openjdk
+      openshift.io/display-name: Red Hat OpenJDK 8
+      sampleContextDir: undertow-servlet
+      sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+      supports: java:8
+      tags: builder,java,openjdk,hidden
+      version: "1.0"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/redhat-openjdk18-openshift:1.0
+    generation: 2
+    importPolicy: {}
+    name: "1.0"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: Build and run Java applications using Maven and OpenJDK 8.
+      iconClass: icon-rh-openjdk
+      openshift.io/display-name: Red Hat OpenJDK 8
+      sampleContextDir: undertow-servlet
+      sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+      supports: java:8
+      tags: builder,java,openjdk,hidden
+      version: "1.1"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/redhat-openjdk18-openshift:1.1
+    generation: 2
+    importPolicy: {}
+    name: "1.1"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: Build and run Java applications using Maven and OpenJDK 8.
+      iconClass: icon-rh-openjdk
+      openshift.io/display-name: Red Hat OpenJDK 8
+      sampleContextDir: undertow-servlet
+      sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+      supports: java:8
+      tags: builder,java,openjdk,hidden
+      version: "1.2"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/redhat-openjdk18-openshift:1.2
+    generation: 2
+    importPolicy: {}
+    name: "1.2"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: Build and run Java applications using Maven and OpenJDK 8.
+      iconClass: icon-rh-openjdk
+      openshift.io/display-name: Red Hat OpenJDK 8
+      sampleContextDir: undertow-servlet
+      sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+      supports: java:8
+      tags: builder,java,openjdk,hidden
+      version: "1.3"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/redhat-openjdk18-openshift:1.3
+    generation: 2
+    importPolicy: {}
+    name: "1.3"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: Build and run Java applications using Maven and OpenJDK 8.
+      iconClass: icon-rh-openjdk
+      openshift.io/display-name: Red Hat OpenJDK 8
+      sampleContextDir: undertow-servlet
+      sampleRepo: https://github.com/jboss-openshift/openshift-quickstarts
+      supports: java:8
+      tags: builder,java,openjdk,hidden
+      version: "1.4"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/redhat-openjdk18-openshift:1.4
+    generation: 2
+    importPolicy: {}
+    name: "1.4"
+    referencePolicy:
+      type: Local
+status:
+  dockerImageRepository: ""

--- a/image-management/applier/operator-inventory/group_vars/seed-hosts.yml
+++ b/image-management/applier/operator-inventory/group_vars/seed-hosts.yml
@@ -3,8 +3,8 @@ openshift_cluster_content:
   content:
   - name: Create Image Builds Project
     template: "{{ inventory_dir }}/../templates/project.yml"
-    params: "{{ inventory_dir }}/../params/image-builds-project"
-    template_action: create
+    params: "{{ inventory_dir }}/../params/image-management-project"
+    action: create
   - name: Create RoleBinding to images project
     template: "{{ inventory_dir }}/../templates/rolebinding.yml"
     params: "{{ inventory_dir}}/../params/builder-rolebinding"

--- a/image-management/applier/params/image-builds/myorg-eap-oraclejdk
+++ b/image-management/applier/params/image-builds/myorg-eap-oraclejdk
@@ -1,6 +1,6 @@
 NAMESPACE=image-builds
 IMAGE_NAME=myorg-eap-oraclejdk
-BASE_IMAGE_STREAM=jboss-eap70-openshift:1.5
+BASE_IMAGE_STREAM=jboss-eap70-openshift:1.7
 OUTPUT_NAMESPACE=openshift
 GIT_URL=https://github.com/redhat-cop/openshift-toolkit
 GIT_REF=master

--- a/image-management/applier/params/image-builds/myorg-openjdk18
+++ b/image-management/applier/params/image-builds/myorg-openjdk18
@@ -1,6 +1,6 @@
 NAMESPACE=image-builds
 IMAGE_NAME=myorg-openjdk18
-BASE_IMAGE_STREAM=redhat-openjdk18-openshift:1.2
+BASE_IMAGE_STREAM=redhat-openjdk18-openshift:1.4
 OUTPUT_NAMESPACE=openshift
 GIT_URL=https://github.com/redhat-cop/openshift-toolkit
 GIT_REF=master

--- a/image-management/applier/patches/jboss-eap70-openshift.yml
+++ b/image-management/applier/patches/jboss-eap70-openshift.yml
@@ -1,0 +1,5 @@
+spec:
+  tags:
+    - name: "1.7"
+      importPolicy:
+        scheduled: true

--- a/image-management/applier/patches/openjdk18-openshift.yml
+++ b/image-management/applier/patches/openjdk18-openshift.yml
@@ -1,0 +1,5 @@
+spec:
+  tags:
+    - name: "1.4"
+      importPolicy:
+        scheduled: true

--- a/image-management/applier/templates/docker-build-git.yml
+++ b/image-management/applier/templates/docker-build-git.yml
@@ -53,6 +53,7 @@ objects:
   kind: ImageStream
   metadata:
     annotations:
+      openshift.io/display-name: ${IS_DISPLAY_NAME}
     generation: 1
     labels:
       build: ${IMAGE_NAME}
@@ -74,3 +75,5 @@ parameters:
   value: webhook123
 - name: GENERIC_WEBHOOK_SECRET
   value: webhook123
+- name: IS_DISPLAY_NAME
+  value: MyOrg.com Sample Image

--- a/image-management/requirements.yml
+++ b/image-management/requirements.yml
@@ -4,5 +4,5 @@
 # From 'openshift-applier'
 - name: openshift-applier
   scm: git
-  src: https://github.com/etsauer/openshift-applier
-  version: patch-containing-strings
+  src: https://github.com/redhat-cop/openshift-applier
+  version: v2.0.9

--- a/image-management/requirements.yml
+++ b/image-management/requirements.yml
@@ -1,8 +1,8 @@
 # This is the Ansible Galaxy requirements file to pull in the correct roles
 # to support the operation of CASL provisioning/runs.
 
-# From 'casl-ansible'
+# From 'openshift-applier'
 - name: openshift-applier
   scm: git
-  src: https://github.com/redhat-cop/openshift-applier
-  version: v3.9.0
+  src: https://github.com/etsauer/openshift-applier
+  version: patch-containing-strings


### PR DESCRIPTION
Working on some updates to the image management workflow, including:

- updating the tag versions and testing compatibility with 3.11
- Updating the README to remove confusion about _Operators_
- Including a `patch` of the base imageStreams to turn on auto-importing from the upstream registry

This PR depends on https://github.com/redhat-cop/openshift-applier/pull/111