### PR TITLE
Use %Y%m%d-%H%M%S timestamps for consistency, fixes #66

### DIFF
--- a/backup_restore/ocp-etcd3-pods-backup.sh
+++ b/backup_restore/ocp-etcd3-pods-backup.sh
@@ -38,7 +38,7 @@ fi
 
 # Vars
 HOSTNAME=$(hostnamectl --static)
-TS=$(date +"%Y%m%d_%H%M%S")
+TS=$(date +"%Y%m%d-%H%M%S")
 
 MASTER_EXEC="/usr/local/bin/master-exec"
 ETCD_POD_MANIFEST="/etc/origin/node/pods/etcd.yaml"

--- a/backup_restore/ocp-master-cert-backup.sh
+++ b/backup_restore/ocp-master-cert-backup.sh
@@ -29,7 +29,7 @@ if ! systemctl status atomic-openshift-master-api >/dev/null 2>&1; then
 fi
 
 #Variable to hold path to tar
-base_file="${DEST_BACKUP_DIR}/${TAR_FILE_PREFIX}-$HOSTNAME-$(date -u '+%Y%m%d-%k%M%S')"
+base_file="${DEST_BACKUP_DIR}/${TAR_FILE_PREFIX}-$HOSTNAME-$(date -u '+%Y%m%d-%H%M%S')"
 tar_name="${base_file}.tar"
 gz_name="${base_file}.tar.gz"
 


### PR DESCRIPTION
This should close out #66 and also make the timestamp format consistent across backups.