### PR TITLE
Fix etcd backup for OCP 3.11

### DIFF
--- a/backup_restore/ocp-etcd3-pods-backup.sh
+++ b/backup_restore/ocp-etcd3-pods-backup.sh
@@ -100,14 +100,14 @@ backup_data() {
   # snapshot output is /var/lib/etcd/ because is mounted from the host, and we can move it later to another host folder.
   # > /usr/local/bin/master-exec etcd etcd /bin/bash -c "ETCDCTL_API=3 /usr/bin/etcdctl \
   # --cert /etc/etcd/peer.crt --key /etc/etcd/peer.key --cacert /etc/etcd/ca.crt --endpoints ${ETCD_EP} snapshot save /var/lib/etcd/snapshot.db"
-  ${MASTER_EXEC} etcd etcd /bin/bash -c "ETCDCTL_API=3 /usr/bin/etcdctl \
+  ${MASTER_EXEC} etcd etcd /bin/sh -c "ETCDCTL_API=3 etcdctl \
   --cert /etc/etcd/peer.crt --key /etc/etcd/peer.key --cacert /etc/etcd/ca.crt \
   --endpoints ${ETCD_EP} snapshot save /var/lib/etcd/snapshot.db"
 
   log "Backing up ETCD data, validating snapshot."
   # Validate the status of the snapshot
   # > snapshot status /var/lib/etcd/snapshot.db 
-  ${MASTER_EXEC} etcd etcd /bin/bash -c "ETCDCTL_API=3 /usr/bin/etcdctl \
+  ${MASTER_EXEC} etcd etcd /bin/sh -c "ETCDCTL_API=3 etcdctl \
   --cert /etc/etcd/peer.crt --key /etc/etcd/peer.key --cacert /etc/etcd/ca.crt \
   --endpoints ${ETCD_EP} snapshot status /var/lib/etcd/snapshot.db"
 


### PR DESCRIPTION
Backup script doesn't work on ocp 3.11 (etcd image: quay.io/coreos/etcd:v3.2.22,sha ff5dd2137a4f).

Removing fully-qualified paths so it works.

Thanks!
