### PR TITLE
Add openshift_machineset_config ansible role

### DIFF
--- a/machine-api/roles/openshift_machineset_config/.yamllint
+++ b/machine-api/roles/openshift_machineset_config/.yamllint
@@ -1,0 +1,4 @@
+---
+rules:
+  line-length:
+    max: 100

--- a/machine-api/roles/openshift_machineset_config/README.adoc
+++ b/machine-api/roles/openshift_machineset_config/README.adoc
@@ -1,0 +1,206 @@
+# openshift_machineset_config
+
+OpenShift 4 MachineSet management to implement custom machinesets such as to
+create dedicated compute and infra nodes.
+
+This Ansible role will query the cluster for the default worker machinesets
+provisioned by the installer and then manage custom machinesets based on the
+discovered worker configuration information.
+
+## Note
+
+As OpenShift 4 is a fast moving target this Ansible role may become obsolete at
+any time. In particular we hope that the standard OpenShift installer or a
+standard OpenShift 4 operator will manage custom machinesets such as to render
+this Ansible role redundant.
+
+## Example Playbooks
+
+Example creating machinesets based on default worker machinesets:
+
+```
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  roles:
+  - role: openshift_machineset_config
+  vars:
+    openshift_machineset_config_disable_default_worker_machinesets: true
+    openshift_machineset_config_groups:
+    - name: compute
+      autoscale: true
+      role: compute
+      total_replicas_min: 3
+      total_replicas_max: 30
+      aws_instance_type: m4.large
+      aws_root_volume_size: 80
+    - name: infra
+      role: infra
+      total_replicas: 2
+      aws_instance_type: m4.large
+```
+
+Example creating machinesets from scratch:
+
+```
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  roles:
+  - role: openshift_machineset_config
+  vars:
+    openshift_machineset_config_cloud_provider: aws
+    openshift_machineset_config_cluster_infra_id: cluster-65b3-gvfpv
+    openshift_machineset_config_aws_iam_instance_profile_id: cluster-65b3-gvfpv-worker-profile
+    openshift_machineset_config_aws_security_group_search_key: tag:Name
+    openshift_machineset_config_aws_security_group_search_value: cluster-65b3-gvfpv-worker-sg
+    openshift_machineset_config_aws_availability_zones:
+    - name: us-east-2a
+      subnet_search_key: tag:Name
+      subnet_search_value: cluster-65b3-gvfpv-private-us-east-2a
+    - name: us-east-2b
+      subnet_search_key: tag:Name
+      subnet_search_value: cluster-65b3-gvfpv-private-us-east-2b
+    - name: us-east-2c
+      subnet_search_key: tag:Name
+      subnet_search_value: cluster-65b3-gvfpv-private-us-east-2c
+    openshift_machineset_config_groups:
+    - name: compute
+      aws_instance_type: m4.large
+      aws_root_volume_size: 80
+      autoscale: true
+      role: compute
+      total_replicas_min: 1
+      total_replicas_max: 30
+    - name: infra
+      aws_instance_type: m4.large
+      role: infra
+      total_replicas: 1
+```
+
+## Installation
+
+```
+ansible-galaxy install \
+https://github.com/redhat-gpte-devopsautomation/ansible-role-openshift_machineset_config/archive/master.tar.gz#/openshift_machineset_config
+```
+
+## Configuration
+
+.Top level configuration variables
+[options="header",cols="30%,10%,60%"]
+|===
+| Variable
+| Default
+| Description
+
+| `openshift_machineset_config_cloud_provider`
+| (detect from default worker machinesets)
+| Cloud provider, currently only "aws" is supported.
+
+| `openshift_machineset_config_cluster_infra_id`
+| (detect from default worker machinesets)
+| Infrastructure tag and label used to identify cluster.
+
+| `openshift_machineset_config_domain`
+| `"openshift-machineset-config.gpte.redhat.com"`
+| Domain used for custom group label.
+
+| `openshift_machineset_config_group_label`
+| `"{{ openshift_machineset_config_domain }}/machineset-group"`
+| Label applied to machinesets to identify machinesets managed by this role.
+
+| `openshift_machineset_config_groups`
+| `[]`
+| Listed of machineset groups, described below.
+
+| `openshift_machineset_config_disable_default_worker_machinesets`
+| `false`
+| Boolean to indicate if default worker machinesets should be scaled to zero.
+
+| `openshift_cluster_autoscaler_spec`
+| `{"scaleDown:{"enabled": true}}`
+| Value for spec section of ClusterAutoscaler definition, applied if any
+machineset enables autoscaling.
+|===
+
+.AWS configuration variables
+[options="header",cols="30%,10%,60%"]
+|===
+| Variable
+| Default
+| Description
+
+| `openshift_machineset_config_aws_availability_zone_data`
+| None
+| JSON output of `aws ec2 describe-subnets --region=$REGION --subnet-ids ...`
+
+| `openshift_machineset_config_aws_availability_zones`
+| (detect from default worker machinesets)
+| Availability zones for worker machinesets
+
+| `openshift_machineset_config_aws_iam_instance_profile_id`
+| (detect from default worker machinesets)
+| AWS IAM instance profile ID
+
+| `openshift_machineset_config_aws_instance_type`
+| `"m4.large"`
+| Default AWS instance type.
+
+| `openshift_machineset_config_aws_root_volume_size`
+| `120`
+| AWS root volume size default in GB
+
+| `openshift_machineset_config_aws_security_group_search_key`
+| (detect from default worker machinesets)
+| Key used to find security group
+
+| `openshift_machineset_config_aws_security_group_search_value`
+| (detect from default worker machinesets)
+| Value used to find security group
+
+| `openshift_machineset_config_aws_tags`
+| Cluster infra id label
+| Tags applied to AWS ec2 instances
+|===
+
+.`openshift_machineset_config_groups` item values
+[options="header",cols="30%,10%,60%"]
+|===
+| Variable
+| Default
+| Description
+
+| `name`
+| (required)
+| Name for machineset config group
+
+| `role`
+| (optional)
+| Value used for default machine and node labels
+
+| `total_replicas`
+| `0`
+| Total number of machineset replicas for non-autoscaling machinesets
+
+| `autoscale`
+| `False`
+| Boolean to indicate if machineautoscaler should be configured for machinesets
+
+| `total_replicas_min`
+| `0`
+| Total minimum number of machineset replicas for non-autoscaling machinesets
+
+| `total_replicas_max`
+| `100`
+| Total maximum number of machineset replicas for non-autoscaling machinesets
+
+| `aws_instance_type`
+| `openshift_machineset_config_aws_instance_type`
+| Default AWS instance type
+
+| `aws_root_volume_size`
+| `openshift_machineset_config_aws_root_volume_size`
+| Default root EBS storage disk size
+|===

--- a/machine-api/roles/openshift_machineset_config/defaults/main.yml
+++ b/machine-api/roles/openshift_machineset_config/defaults/main.yml
@@ -1,0 +1,39 @@
+---
+
+# Required if no default worker machinesets found
+#openshift_machineset_config_cloud_provider: ...
+#openshift_machineset_config_cluster_infra_id: ...
+
+openshift_machineset_config_domain: openshift-machineset-config.gpte.redhat.com
+openshift_machineset_config_group_label: "{{ openshift_machineset_config_domain }}/machineset-group"
+openshift_machineset_config_groups: []
+openshift_machineset_config_disable_default_worker_machinesets: false
+
+openshift_cluster_autoscaler_spec:
+  scaleDown:
+    enabled: true
+
+#
+# AWS configuration
+#
+
+# Default ist of availability zones for machinesets
+#openshift_machineset_config_aws_availability_zones
+
+# JSON output of `aws ec2 describe-subnets --region=$REGION --subnet-ids ...`
+#openshift_machineset_config_aws_availability_zone_data:
+
+# List of availability zones with configuration
+#openshift_machineset_config_aws_availability_zones:
+
+# Must be set globally or on machineset groups as `aws_iam_instance_profile_id`
+#openshift_machineset_config_aws_iam_instance_profile_id: ...
+
+# Default instance type for machinesets
+openshift_machineset_config_aws_instance_type: m4.large
+
+# Default root volume size for machines
+openshift_machineset_config_aws_root_volume_size: 120
+
+# Must be set globally or on machineset groups as `aws_tags`
+#openshift_machineset_config_aws_tags: ...

--- a/machine-api/roles/openshift_machineset_config/meta/main.yml
+++ b/machine-api/roles/openshift_machineset_config/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  role_name: openshift_machineset_config
+  author: Johnathan Kupferer
+  description: Configure OpenShift 4 MachineSets
+  license: MIT
+  min_ansible_version: 2.7
+  platforms:
+  - name: GenericLinux
+    versions:
+    - all
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/machine-api/roles/openshift_machineset_config/tasks/aws-machineset-group.yml
+++ b/machine-api/roles/openshift_machineset_config/tasks/aws-machineset-group.yml
@@ -1,0 +1,71 @@
+---
+- name: Define {{ machineset_group.name }} machinesets
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'aws-machineset.yml.j2') | from_yaml }}"
+  # Iterate through availability zones in reverse order as it makes the math
+  # easier to scale zone "a" before "b" to match expected behavior.
+  loop: "{{ availability_zones[::-1] }}"
+  loop_control:
+    label: "{{ machineset_name }}"
+    loop_var: availability_zone
+    index_var: loop_index
+  vars:
+    ami_id: >-
+      {{ machineset_group.aws_ami_id
+       | default(aws_coreos_ami_id_by_region[region])
+      }}
+    region: >-
+      {{ availability_zone.name[:-1] }}
+    subnet_search_key: >-
+      {{ availability_zone.subnet_search_key
+       | default('subnet-id')
+      }}
+    subnet_search_value: >-
+      {{ availability_zone.subnet_search_value }}
+    instance_type: >-
+      {{ machineset_group.aws_instance_type | default(default_aws_instance_type) }}
+    machineset_name: >-
+      {{ [cluster_infra_id, machineset_group.name, availability_zone.name] | join('-') }}
+    machineset_node_labels: >-
+      {{ machineset_group.node_labels
+       | default({'node-role.kubernetes.io/' + machineset_group.role: ''}
+           if machineset_group.role|default(False) else {})
+      }}
+    machineset_group_total_replicas: >-
+      {{ machineset_group.total_replicas
+       | default(machineset_group.total_replicas_min)
+       | default(0)
+      }}
+    machineset_replicas: >-
+      {{ (
+        (machineset_group_total_replicas|int + loop_index) / availability_zones|count
+      ) | int }}
+    root_volume_size: >-
+      {{ machineset_group.aws_root_volume_size | default(default_aws_root_volume_size) }}
+
+- name: Define {{ machineset_group.name }} machineautoscalers
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'machineautoscaler.yml.j2') | from_yaml }}"
+  # Iterate through availability zones in reverse order as it makes the math
+  # easier to scale zone "a" before "b" to match expected behavior.
+  loop: "{{ availability_zones[::-1] }}"
+  loop_control:
+    label: "{{ machineset_name }}"
+    loop_var: availability_zone
+    index_var: loop_index
+  vars:
+    machineset_name: >-
+      {{ [cluster_infra_id, machineset_group.name, availability_zone.name] | join('-') }}
+    machineset_min_replicas: >-
+      {{ (
+         (machineset_group.total_replicas_min|default(0) + loop_index) /
+         availability_zones|count
+      ) | int }}
+    machineset_max_replicas: >-
+      {{ (
+         (machineset_group.total_replicas_max|default(100) + loop_index) /
+         availability_zones|count
+      ) | int }}
+  when: machineset_group.autoscale | default(False) | bool

--- a/machine-api/roles/openshift_machineset_config/tasks/aws.yml
+++ b/machine-api/roles/openshift_machineset_config/tasks/aws.yml
@@ -1,0 +1,73 @@
+---
+- name: Define custom machinesets
+  include_tasks: aws-machineset-group.yml
+  loop: "{{ openshift_machineset_config_groups }}"
+  loop_control:
+    label: "{{ machineset_group.name }}"
+    loop_var: machineset_group
+  vars:
+    iam_instance_profile_id: >-
+      {{ machineset_group.aws_iam_instance_profile_id
+       | default(openshift_machineset_config_aws_iam_instance_profile_id)
+       | default(reference_provider_spec_value_iam_instance_profile_id)
+      }}
+    security_group_search_key: >-
+      {{ machineset_group.aws_security_group_search_key
+       | default(openshift_machineset_config_aws_security_group_search_key)
+       | default(reference_provider_security_group_search_key)
+       | default('group-id', True)
+      }}
+    security_group_search_value: >-
+      {{ machineset_group.aws_security_group_search_value
+       | default(openshift_machineset_config_aws_security_group_search_value)
+       | default(reference_provider_security_group_search_value)
+      }}
+    aws_tags: >-
+      {{ machineset_group.aws_tags
+       | default(openshift_machineset_config_aws_tags)
+       | default(reference_provider_tags)
+       | combine({'kubernetes.io/cluster/' ~ cluster_infra_id: 'owned'})
+      }}
+    cluster_infra_id: >-
+      {{ openshift_machineset_config_cluster_infra_id }}
+    reference_provider_spec_value: >-
+      {{ default_worker_machinesets
+       | json_query('[0].spec.template.spec.providerSpec.value')
+       | default({}, True)
+      }}
+    reference_provider_spec_value_iam_instance_profile_id: >-
+      {% if reference_provider_spec_value -%}
+      {{ reference_provider_spec_value.iamInstanceProfile.id }}
+      {%- endif %}
+    reference_provider_security_group_search_key: >-
+      {% if reference_provider_spec_value -%}
+      {{ reference_provider_spec_value.securityGroups[0].filters[0].name }}
+      {%- endif %}
+    reference_provider_security_group_search_value: >-
+      {% if reference_provider_spec_value -%}
+      {{ reference_provider_spec_value.securityGroups[0].filters[0]['values'][0] }}
+      {%- endif %}
+    reference_provider_tags: >-
+      {{ reference_provider_spec_value.tags
+       | default([])
+       | items2dict(key_name='name', value_name='value')
+      }}
+    user_data_secret: >-
+      {{ machineset_group.aws_user_data_secret
+       | default('worker-user-data')
+      }}
+    availability_zones: >-
+      {{ machineset_group.aws_availability_zones
+       | default(default_aws_availability_zones)
+       | default(default_worker_availability_zones, true)
+      }}
+    default_worker_availability_zones: >-
+      {{ default_worker_machinesets
+       | json_query(worker_availability_zone_query)
+      }}
+    worker_availability_zone_query: >-
+      [].{
+        "name": spec.template.spec.providerSpec.value.placement.availabilityZone,
+        "subnet_search_key": spec.template.spec.providerSpec.value.subnet.filters[0].name
+        "subnet_search_value": spec.template.spec.providerSpec.value.subnet.filters[0].values[0]
+      }

--- a/machine-api/roles/openshift_machineset_config/tasks/disable-default-worker-machinesets.yml
+++ b/machine-api/roles/openshift_machineset_config/tasks/disable-default-worker-machinesets.yml
@@ -1,0 +1,16 @@
+---
+- name: Scale base worker machinesets to zero
+  k8s:
+    state: present
+    definition:
+      apiVersion: machine.openshift.io/v1beta1
+      kind: MachineSet
+      metadata:
+        name: "{{ machineset.metadata.name }}"
+        namespace: openshift-machine-api
+      spec:
+        replicas: 0
+  loop: "{{ default_worker_machinesets }}"
+  loop_control:
+    label: "{{ machineset.metadata.name }}"
+    loop_var: machineset

--- a/machine-api/roles/openshift_machineset_config/tasks/enable-cluster-autoscaler.yml
+++ b/machine-api/roles/openshift_machineset_config/tasks/enable-cluster-autoscaler.yml
@@ -1,0 +1,5 @@
+---
+- name: Define clusterautoscaler
+  k8s:
+    state: present
+    definition: "{{ lookup('template', 'clusterautoscaler.yml.j2') | from_yaml }}"

--- a/machine-api/roles/openshift_machineset_config/tasks/main.yml
+++ b/machine-api/roles/openshift_machineset_config/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Set machineset facts
+  include_tasks: set-facts.yml
+
+- name: Configure machinesets for cloud provider
+  include_tasks: "{{ openshift_machineset_config_cloud_provider }}.yml"
+
+- name: Disable default worker machinesets
+  include_tasks: disable-default-worker-machinesets.yml
+  when: disable_default_worker_machinesets|bool
+
+- name: Enable cluster autoscaler
+  include_tasks: enable-cluster-autoscaler.yml
+  when: >-
+    openshift_machineset_config_groups | json_query('[?autoscale]')

--- a/machine-api/roles/openshift_machineset_config/tasks/set-facts.yml
+++ b/machine-api/roles/openshift_machineset_config/tasks/set-facts.yml
@@ -1,0 +1,51 @@
+---
+- name: Get machinesets
+  k8s_facts:
+    api_version: machine.openshift.io/v1beta1
+    kind: MachineSet
+    namespace: openshift-machine-api
+  register: r_get_machinesets
+
+- name: Set default_worker_machinesets
+  set_fact:
+    current_machinesets: >-
+      {{ r_get_machinesets.resources }}
+    current_machineset_names: >-
+      {{ r_get_machinesets.resources
+       | json_query('[].metadata.name')
+      }}
+    default_worker_machinesets: >-
+      {{ r_get_machinesets.resources
+       | json_query(default_worker_machineset_json_query)
+      }}
+  vars:
+    # Base worker machinesets will lack machineset group label
+    default_worker_machineset_json_query: >-
+      [?!contains(keys(metadata.labels), '{{ machineset_group_label }}')]
+
+- name: Set cluster facts
+  set_fact:
+    openshift_machineset_config_cluster_infra_id: >-
+      {{ reference_machineset.metadata.labels['machine.openshift.io/cluster-api-cluster'] }}
+    openshift_machineset_config_cloud_provider: >-
+      {{ reference_provider_spec_value.apiVersion
+       | regex_replace('providerconfig\.openshift\.io/v1beta1', '')
+      }}
+  vars:
+    reference_machineset: >-
+      {{ default_worker_machinesets[0] | default({}) }}
+    reference_provider_spec_value: >-
+      {{ reference_machineset
+       | json_query('spec.template.spec.providerSpec.value')
+      }}
+  when: default_worker_machinesets
+
+- name: Fail if openshift_machineset_config_cloud_provider is undefined
+  fail:
+    msg: openshift_machineset_config_cloud_provider is required
+  when: openshift_machineset_config_cloud_provider is undefined
+
+- name: Fail if openshift_machineset_config_cluster_infra_id is undefined
+  fail:
+    msg: openshift_machineset_config_cluster_infra_id is required
+  when: openshift_machineset_config_cluster_infra_id is undefined

--- a/machine-api/roles/openshift_machineset_config/templates/aws-machineset.yml.j2
+++ b/machine-api/roles/openshift_machineset_config/templates/aws-machineset.yml.j2
@@ -1,0 +1,84 @@
+---
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: {{ machineset_name | to_json }}
+  namespace: openshift-machine-api
+  labels:
+    {{ machineset_group_label | to_json }}: {{ machineset_group.name | to_json }}
+    machine.openshift.io/cluster-api-cluster: {{ cluster_infra_id | to_json }}
+spec:
+
+{# Do not set replicas on existing autoscaling machinesets #}
+{% if machineset_name not in current_machineset_names
+   or not machineset_group.autoscale|default(False)
+%}
+  replicas: {{ machineset_replicas | int | to_json }}
+{% endif %}
+
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: {{ cluster_infra_id | to_json }}
+{% if 'role' in machineset_group %}
+      machine.openshift.io/cluster-api-machine-role: {{ machineset_group.role | to_json }}
+      machine.openshift.io/cluster-api-machine-type: {{ machineset_group.role | to_json }}
+{% endif %}
+      machine.openshift.io/cluster-api-machineset: {{ machineset_name | to_json }}
+
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        {{ machineset_group_label }}: {{ machineset_group.name | to_json }}
+        machine.openshift.io/cluster-api-cluster: {{ cluster_infra_id | to_json }}
+{% if 'role' in machineset_group %}
+        machine.openshift.io/cluster-api-machine-role: {{ machineset_group.role | to_json }}
+        machine.openshift.io/cluster-api-machine-type: {{ machineset_group.role | to_json }}
+{% endif %}
+        machine.openshift.io/cluster-api-machineset: {{ machineset_name | to_json }}
+    spec:
+      metadata:
+        creationTimestamp: null
+        labels: {{ machineset_node_labels | to_json }}
+      providerSpec:
+        value:
+          ami:
+            id: {{ ami_id | to_json }}
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          blockDevices:
+          - ebs:
+              iops: 0
+              volumeSize: {{ root_volume_size | int | to_json }}
+              volumeType: gp2
+          credentialsSecret:
+            name: aws-cloud-credentials
+          deviceIndex: 0
+          iamInstanceProfile:
+            id: {{ iam_instance_profile_id | to_json }}
+          instanceType: {{ instance_type | to_json }}
+          kind: AWSMachineProviderConfig
+          metadata:
+            creationTimestamp: null
+          placement:
+            availabilityZone: {{ availability_zone.name | to_json }}
+            region: {{ region | to_json }}
+          publicIp: null
+          securityGroups:
+          - filters:
+            - name: {{ security_group_search_key | to_json }}
+              values:
+              - {{ security_group_search_value | to_json }}
+          subnet:
+            filters:
+            - name: {{ subnet_search_key | to_json }}
+              values:
+              - {{ subnet_search_value | to_json }}
+          tags:
+{% for name, value in aws_tags.items() %}
+          - name: {{ name | to_json }}
+            value: {{ value | to_json }}
+{% endfor %}
+          userDataSecret:
+            name: {{ user_data_secret | to_json }}
+      versions:
+        kubelet: ""

--- a/machine-api/roles/openshift_machineset_config/templates/clusterautoscaler.yml.j2
+++ b/machine-api/roles/openshift_machineset_config/templates/clusterautoscaler.yml.j2
@@ -1,0 +1,6 @@
+---
+apiVersion: autoscaling.openshift.io/v1
+kind: ClusterAutoscaler
+metadata:
+  name: default
+spec: {{ openshift_cluster_autoscaler_spec | to_json }}

--- a/machine-api/roles/openshift_machineset_config/templates/machineautoscaler.yml.j2
+++ b/machine-api/roles/openshift_machineset_config/templates/machineautoscaler.yml.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: autoscaling.openshift.io/v1beta1
+kind: MachineAutoscaler
+metadata:
+  name: {{ machineset_name }}
+  namespace: openshift-machine-api
+spec:
+  minReplicas: {{ machineset_min_replicas }}
+  maxReplicas: {{ machineset_max_replicas }}
+  scaleTargetRef:
+    apiVersion: machine.openshift.io/v1beta1
+    kind: MachineSet
+    name: {{ machineset_name }}

--- a/machine-api/roles/openshift_machineset_config/vars/main.yml
+++ b/machine-api/roles/openshift_machineset_config/vars/main.yml
@@ -1,0 +1,55 @@
+---
+config_domain: "{{ openshift_machineset_config_domain }}"
+
+disable_default_worker_machinesets: >-
+  {{ openshift_machineset_config_disable_default_worker_machinesets | bool }}
+
+machineset_group_label: "{{ openshift_machineset_config_group_label }}"
+machineset_groups: "{{ openshift_machineset_config_groups }}"
+
+#
+# AWS variables
+#
+default_aws_instance_type: >-
+  {{ openshift_machineset_config_aws_instance_type }}
+default_aws_root_volume_size: >-
+  {{ openshift_machineset_config_aws_root_volume_size }}
+
+# 
+default_aws_availability_zones: >-
+  {{ openshift_machineset_config_aws_availability_zones
+   | default(queried_aws_availability_zones)
+  }}
+
+# AWS availability zone information process from aws cli output
+queried_aws_availability_zones: >-
+  {{ openshift_machineset_config_aws_availability_zone_data
+   | default({})
+   | json_query(aws_availability_zones_query)
+  }}
+
+# JMESpath query to convert aws cli output to required configuration format
+aws_availability_zones_query: >-
+  Subnets[*].{
+    "name": AvailabilityZone,
+    "subnet_search_key": 'subnet-id',
+    "subnet_search_value": SubnetId
+  }
+# List of coreos ami ids:
+# https://docs.openshift.com/container-platform/4.1/installing/installing_aws_user_infra/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra
+aws_coreos_ami_id_by_region:
+  ap-northeast-1: ami-0c63b39219b8123e5
+  ap-northeast-2: ami-073cba0913d2250a4
+  ap-south-1: ami-0270be11430101040
+  ap-southeast-1: ami-06eb9d35ede4f08a3
+  ap-southeast-2: ami-0d980796ce258b5d5
+  ca-central-1: ami-0f907257d1686e3f7
+  eu-central-1: ami-02fdd627029c0055b
+  eu-west-1: ami-0d4839574724ed3fa
+  eu-west-2: ami-053073b95aa285347
+  eu-west-3: ami-09deb5deb6567bcd5
+  sa-east-1: ami-068a2000546e1889d
+  us-east-1: ami-046fe691f52a953f9
+  us-east-2: ami-0649fd5d42859bdfc
+  us-west-1: ami-0c1d2b5606111ac8c
+  us-west-2: ami-00745fcbb14a863ed


### PR DESCRIPTION
Adding ansible role for openshift_machineset_config. Role information in the README.adoc. More content around machine-api management should be added along with this, but is not in this PR.