### PR TITLE
Fixed deadlinks caused by ocp latest docs pointing to 4.x

### DIFF
--- a/custom-autoscaler/README.md
+++ b/custom-autoscaler/README.md
@@ -1,6 +1,6 @@
 # OpenShift Custom Autoscaler Quickstart
 
-The following illustrates how one might use OpenShift's [metrics stack](https://docs.openshift.com/container-platform/latest/install_config/cluster_metrics.html) (Hawkular, Cassandra, Heapster) to develop customized application autoscaling.
+The following illustrates how one might use OpenShift's [metrics stack](https://docs.openshift.com/container-platform/3.11/install_config/cluster_metrics.html) (Hawkular, Cassandra, Heapster) to develop customized application autoscaling.
 
 ## Running & Testing
 

--- a/networkpolicy/README.md
+++ b/networkpolicy/README.md
@@ -1,10 +1,10 @@
 # NetworkPolicy
 
-Tools to configure OpenShift with a set of baseline [NetworkPolicy](https://docs.openshift.com/container-platform/latest/admin_guide/managing_networking.html) objects
+Tools to configure OpenShift with a set of baseline [NetworkPolicy](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_networking.html) objects
 
 ## Overview
 
-The [OpenShift SDN](https://docs.openshift.com/container-platform/latest/install_config/configuring_sdn.html) offers several plugin implementations. One of these plugins supports NetworkPolicy, which provides for more fine grained policies for communication between pods running on the cluster. Once enabled, all communication between pods within OpenShift are not restricted in any way. The tools within this repository will configure an OpenShift environment with a set of default policies that support a [zero trust network](https://tigera.io/wp-content/uploads/2017/12/wp-tigera-zero-trust-cloud-native-environment.pdf).
+The [OpenShift SDN](https://docs.openshift.com/container-platform/3.11/install_config/configuring_sdn.html) offers several plugin implementations. One of these plugins supports NetworkPolicy, which provides for more fine grained policies for communication between pods running on the cluster. Once enabled, all communication between pods within OpenShift are not restricted in any way. The tools within this repository will configure an OpenShift environment with a set of default policies that support a [zero trust network](https://tigera.io/wp-content/uploads/2017/12/wp-tigera-zero-trust-cloud-native-environment.pdf).
 
 The following sections describes the relevant concepts along with tooling to automate the application of these policies to an OpenShift environment.
 
@@ -58,7 +58,7 @@ Additional namespaces may be configured if desired.
 
 ### Allow Traffic from the Default Namespace
 
-OpenShift provides a routing layer to external traffic to access applications within the cluster. Since traffic traverses through router(s) which are deployed within the _default_ namespace, a trust must be established between projects and the default namespace for traffic to flow properly. The NetworkPolicy [allow-from-default-namespace.yml](policies/baseline/allow-from-default.yml) is available that should be applied to all projects.
+OpenShift provides a routing layer to external traffic to access applications within the cluster. Since traffic traverses through router(s) which are deployed within the _default_ namespace, a trust must be established between projects and the default namespace for traffic to flow properly. The NetworkPolicy [allow-from-default-namespace.yml](policies/baseline/allow-from-default-namespace.yml) is available that should be applied to all projects.
 
 ### Configure Existing Projects
 
@@ -75,7 +75,7 @@ done
 
 ### Default Policies for New Projects
 
-In a prior section, Network Policies were applied to disable inter namespace communication while allowing access from the _default_ namespace to support ingress from the Router. These same set of policies can be applied for any new project that is created within OpenShift by [modifying the Default Project Template](https://docs.openshift.com/container-platform/latest/admin_guide/managing_projects.html#modifying-the-template-for-new-projects).
+In a prior section, Network Policies were applied to disable inter namespace communication while allowing access from the _default_ namespace to support ingress from the Router. These same set of policies can be applied for any new project that is created within OpenShift by [modifying the Default Project Template](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#modifying-the-template-for-new-projects).
 
 The following Ansible inventory content can be provided at cluster install time and placed within the `[OSEv3:vars]` group:
 

--- a/quota-management/README.md
+++ b/quota-management/README.md
@@ -179,7 +179,7 @@ This section describes a few ways we can advance the solution through advanced c
 
 ### (Recommended) Add the desired default Profile to the default project template
 
-OpenShift allows cluster administrators to customize the default template that is used to create projects when a user runs `oc new-project`. That process is described further in the [OpenShift Documentation](https://docs.openshift.com/container-platform/latest/admin_guide/managing_projects.html#modifying-the-template-for-new-projects).
+OpenShift allows cluster administrators to customize the default template that is used to create projects when a user runs `oc new-project`. That process is described further in the [OpenShift Documentation](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#modifying-the-template-for-new-projects).
 
 In order to lower the overhead in our process, we can embed the Small _tier profile_ in our cluster's default project template. This way, every project that gets created will, by default, be restrcted by a small quota. An example of what this default project template looks like can be found in `files/default-project-template.yml`.
 
@@ -187,7 +187,7 @@ With that template applied and configured, this ensures that all projects in our
 
 ### (Recommended) Automate the process further using the openshift-applier
 
-The [openshift-applier](https://github.com/redhat-cop/casl-ansible/tree/master/roles/openshift-applier) is an ansible role that supports declarative automation for rolling out OpenShift resources. This role can be used to declare a set of projects and their quotas, and keep them up to date with ansible. Here's a sample of how you would define the ansible variables to accomplish this.
+The [openshift-applier](https://github.com/redhat-cop/openshift-applier) is an ansible role that supports declarative automation for rolling out OpenShift resources. This role can be used to declare a set of projects and their quotas, and keep them up to date with ansible. Here's a sample of how you would define the ansible variables to accomplish this.
 
 ```
 openshift_cluster_content:


### PR DESCRIPTION
- Fixed deadlinks caused by ocp latest docs pointing to 4.x
- Fixed deadlink to networt policy yml example
- Fixed deadlink to applier repo