### PR TITLE
storage/pv-to-path-mapping - init add

### DIFF
--- a/storage/pv-to-path-mapping
+++ b/storage/pv-to-path-mapping
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# map PVS to storage paths
+printf "%-40s\t%-40s\t%s\n" "PATH" "PV" "CLAIM"
+PVS=$(oc get pv -o jsonpath='{.items[*].metadata.name}' | tr ' ' "\n")
+declare -A PATH_TO_PV_MAP
+while read pv <&3; do
+  path=$(oc describe pv ${pv} | grep Path: | awk '{print $2}')
+  claim=$(oc describe pv ${pv} | grep Claim: | awk '{print $2}')
+
+  printf "%-40s\t%-40s\t%s\n" "${path}" "${pv}" "${claim}"
+done 3<<<"${PVS}"
+

--- a/storage/pv-to-path-mapping
+++ b/storage/pv-to-path-mapping
@@ -5,8 +5,8 @@ printf "%-40s\t%-40s\t%s\n" "PATH" "PV" "CLAIM"
 PVS=$(oc get pv -o jsonpath='{.items[*].metadata.name}' | tr ' ' "\n")
 declare -A PATH_TO_PV_MAP
 while read pv <&3; do
-  path=$(oc describe pv ${pv} | grep Path: | awk '{print $2}')
-  claim=$(oc describe pv ${pv} | grep Claim: | awk '{print $2}')
+  path=$(oc get pv ${pv} -o jsonpath='{.spec..path}')
+  claim=$(oc get pv ${pv} -o jsonpath='{.spec.claimRef.name}')
 
   printf "%-40s\t%-40s\t%s\n" "${path}" "${pv}" "${claim}"
 done 3<<<"${PVS}"


### PR DESCRIPTION
companion to https://github.com/redhat-cop/openshift-toolkit/pull/117

since within the context of the gluster pod can't also get the mapping to the PV and PVC this tool will print a pretty table of those mappings when you need to figure out which PV/PVC is affected by a gluster health issue.