### PR TITLE
use oc client to fix terminating

### DIFF
--- a/fix-project-terminating/README.md
+++ b/fix-project-terminating/README.md
@@ -28,7 +28,7 @@ status:
 > oc patch <object-type> <object-name> -p '{"metadata":{"finalizers": []}}' --type=merge
 ```
 
-### Patch project/namespace script using curl or oc client
+### Patch project/namespace script using curl and oc client or certs
 
 In other cases, however, the project/namespace seems stuck by having a finalizer on the project itself. In that case, the script found here - `fix-terminating.sh` can be utilized to patch the namespace utilizing curl. Note that this script may need to be executed where the necessary certs exists (obtained on the OpenShift master node).
 

--- a/fix-project-terminating/README.md
+++ b/fix-project-terminating/README.md
@@ -28,10 +28,18 @@ status:
 > oc patch <object-type> <object-name> -p '{"metadata":{"finalizers": []}}' --type=merge
 ```
 
-### Patch project/namespace using curl
+### Patch project/namespace script using curl or oc client
 
-In other cases, however, the project/namespace seems stuck by having a finalizer on the project itself. In that case, the script found here - `fix-terminating.sh` can be utilized to patch the namespace utilizing curl. Note that this script needs to be executed where the necessary certs exists (obtained on the OpenShift master node). 
+In other cases, however, the project/namespace seems stuck by having a finalizer on the project itself. In that case, the script found here - `fix-terminating.sh` can be utilized to patch the namespace utilizing curl. Note that this script may need to be executed where the necessary certs exists (obtained on the OpenShift master node).
+
+with certs
 
 ```bash
 > bash fix-terminating.sh <cluster-url> <namespace>
+```
+
+or without certs and with the oc client
+
+```bash
+> bash fix-terminating.sh -c <namespace>
 ```

--- a/fix-project-terminating/fix-terminating.sh
+++ b/fix-project-terminating/fix-terminating.sh
@@ -1,16 +1,56 @@
 #!/bin/bash
 
-clusterurl=$1
-namespace=$2
-cacert=${3:-/etc/origin/master/ca.crt}
-cert=${4:-/etc/origin/master/admin.crt}
-key=${5:-/etc/origin/master/admin.key}
+useoc=false
 
-curl -X PUT \
-     --data "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"name\":\"${namespace}\"},\"spec\":{\"finalizers\":[]}}" \
-     -H "Content-Type: application/json" \
-     -cacert ${cacert} \
-     --cert ${cert} \
-     --key ${key} \
-     ${clusterurl}/api/v1/namespaces/${namespace}/finalize
+usage()
+{
+  printf "\nfix-terminating.sh\n\n"
+  echo "examples"
+  echo "  # Use the oc client to fix my-project
+  echo "  bash fix-terminating.sh -c my-project
+  echo "  # Use certs to fix my-project
+  echo "  bash fix-terminating.sh /path/to/ca.crt /path/to/admin.crt /path/to/admin.key https://cluster:443 my-project
+  printf "\n"
+}
 
+while (( "$#" )); do
+  case $1 in
+    -c | --use-oc)             useoc=true
+                               shift
+                               namespace=$1
+                               ;;
+    -h | --help)               usage
+                               exit 1
+                               ;;
+  esac
+  shift
+done
+
+data="{\"apiVersion\":\"v1\",\"kind\":\"Namespace\",\"metadata\":{\"name\":\"${namespace}\"},\"spec\":{\"finalizers\":[]}}"
+
+if [ "true" == "$useoc" ]
+then
+  printf "\nusing oc client. Ensure you are logged in\n terminating $namespace \n"
+  token=$(oc whoami -t)
+  clusterurl=$(oc whoami --show-server)
+
+  curl -X PUT -H "Content-Type: application/json" \
+    --data  ${data} \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $token" \
+    ${clusterurl}/api/v1/namespaces/${namespace}/finalize
+else
+  clusterurl=$1
+  namespace=$2
+  cacert=${3:-/etc/origin/master/ca.crt}
+  cert=${4:-/etc/origin/master/admin.crt}
+  key=${5:-/etc/origin/master/admin.key}
+
+  printf "\nusing certs\n"
+  curl -X PUT -H "Content-Type: application/json" \
+    --data  ${data} \
+    -cacert ${cacert} \
+    --cert ${cert} \
+    --key ${key} \
+    ${clusterurl}/api/v1/namespaces/${namespace}/finalize
+fi

--- a/fix-project-terminating/fix-terminating.sh
+++ b/fix-project-terminating/fix-terminating.sh
@@ -36,7 +36,6 @@ then
 
   curl -X PUT -H "Content-Type: application/json" \
     --data  ${data} \
-    -H "Content-Type: application/json" \
     -H "Authorization: Bearer $token" \
     ${clusterurl}/api/v1/namespaces/${namespace}/finalize
 else


### PR DESCRIPTION
Updates the script to give the user the option to use the oc client instead of certs. Assumes the user has the correct privileges. Leverages the oc client to get the users token and current server then makes the curl request.

old way (still available) leveraging certs:

```
bash fix-terminating.sh <cluster-url> <namespace> 
```

optional new way

```
bash fix-terminating.sh -c <namespace>
```