### PR TITLE
Add --all-namespaces to force kill of hanging pods in any namespace o…

### DIFF
--- a/maintenance_cleanup/delete-dead-pods.sh
+++ b/maintenance_cleanup/delete-dead-pods.sh
@@ -50,8 +50,8 @@ if [ "$dryrun" = "false" ]; then
     {system("bash -c '\''oc delete pod -n "$1" "$2" '\''")}'
 
   #Force kill any hanging pods
-  oc get pods --no-headers | awk '$4 == "Terminating" \
-    {system("bash -c '\''oc delete pod -n "$1" "$2" --grace-period=0 '\''")}'
+  oc get pods --all-namespaces --no-headers | awk '$4 == "Terminating" \
+    {system("bash -c '\''oc delete pod -n "$1" "$2" --force --grace-period=0 '\''")}'
 
   exit 0
 fi


### PR DESCRIPTION
Hi,
   i've included `--all-namespaces` parameter on the force kill part of the script to delete hanging pods executing in other namespaces than current one.
In some cases, hanging pods pods wasn't killed unless --force command was included in the `oc delete` command.

Regards